### PR TITLE
Add redirect_uri option

### DIFF
--- a/lib/omniauth/strategies/clever.rb
+++ b/lib/omniauth/strategies/clever.rb
@@ -14,6 +14,7 @@ module OmniAuth
         :authorize_url => 'https://clever.com/oauth/authorize',
         :token_url     => 'https://clever.com/oauth/tokens'
       }
+      option :redirect_uri, nil
 
       # This option bubbles up to the OmniAuth::Strategies::OAuth2
       # when we call super in the callback_phase below.
@@ -60,7 +61,7 @@ module OmniAuth
 
       # Fix unknown redirect uri bug by NOT appending the query string to the callback url.
       def callback_url
-        full_host + script_name + callback_path
+        options[:redirect_uri] || (full_host + script_name + callback_path)
       end
     end
   end


### PR DESCRIPTION
The `omniauth-clever` gem is missing any way to specify a specific redirect URI for the integration to use in Clever. If a Clever app is configured with more than one redirect URI in their settings, this allows for configuring which to use.

For reference, the Google OAuth2 strategy does similar here: https://github.com/zquestz/omniauth-google-oauth2/blob/master/lib/omniauth/strategies/google_oauth2.rb#L103